### PR TITLE
Fix Dateext

### DIFF
--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -639,8 +639,8 @@ namespace logrotate
             {
                 string time_str = lrc.DateFormat;
                 time_str = time_str.Replace("%Y", DateTime.Now.Year.ToString());
-                time_str = time_str.Replace("%m", DateTime.Now.Month.ToString());
-                time_str = time_str.Replace("%d", DateTime.Now.Day.ToString());
+                time_str = time_str.Replace("%m", DateTime.Now.Month.ToString("D2"));
+                time_str = time_str.Replace("%d", DateTime.Now.Day.ToString("D2"));
                 time_str = time_str.Replace("%s", ((double)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString());
                 rotate_name = fi.Name + time_str;
             }


### PR DESCRIPTION
%m and %d should be with two digits (From 01 to 31).

I am not a C# dev and I don't have the software to compile, but I found that here :
https://msdn.microsoft.com/en-us/library/8wch342y%28v=vs.110%29.aspx

Should fix #1 
