### PR TITLE
Fix for edge case crash of rotated filenames

### DIFF
--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -667,7 +667,7 @@ namespace logrotate
                 return;
 
             // look for any rotated log files, and rename them with the count if not using dateext
-            Regex pattern = new Regex("[0-9]");
+            Regex pattern = new Regex("^[0-9]$");
 
             // sort alphabetically reversed
             Array.Sort<FileSystemInfo>(fis, delegate(FileSystemInfo a, FileSystemInfo b)


### PR DESCRIPTION
If a file extension part has a number in it (eg, "log-20150101" or "bz2") and we're not using the dateext setting, rotating old logs will crash with a String->Number converstion.  This change makes sure we are only trying to convert a number, and not just a string with only a number in it
