### PR TITLE
Changes to dateformat interpolation and application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -189,4 +189,3 @@ _Pvt_Extensions/
 ModelManifest.xml
 /logrotateconf/
 /logrotategui/
-/.vs/logrotate/v15/Server/sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -189,3 +189,4 @@ _Pvt_Extensions/
 ModelManifest.xml
 /logrotateconf/
 /logrotategui/
+/.vs/logrotate/v15/Server/sqlite3

--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -640,10 +640,10 @@ namespace logrotate
                 string time_str = lrc.DateFormat;
                 DateTime now = DateTime.Now;
                 time_str = time_str.Replace("%Y", now.Year.ToString());
-                time_str = time_str.Replace("%M", now.Month.ToString("D2"));
+                time_str = time_str.Replace("%m", now.Month.ToString("D2"));
                 time_str = time_str.Replace("%d", now.Day.ToString("D2"));
                 time_str = time_str.Replace("%H", now.Hour.ToString("D2"));
-                time_str = time_str.Replace("%m", now.Minute.ToString("D2"));
+                time_str = time_str.Replace("%M", now.Minute.ToString("D2"));
                 time_str = time_str.Replace("%s", ((double)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString());
                 // rotate_name = fi.Name + time_str;
                 rotate_name = Path.GetFileNameWithoutExtension(fi.Name) +

--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -638,9 +638,12 @@ namespace logrotate
             if (lrc.DateExt)
             {
                 string time_str = lrc.DateFormat;
-                time_str = time_str.Replace("%Y", DateTime.Now.Year.ToString());
-                time_str = time_str.Replace("%m", DateTime.Now.Month.ToString("D2"));
-                time_str = time_str.Replace("%d", DateTime.Now.Day.ToString("D2"));
+                DateTime now = DateTime.Now;
+                time_str = time_str.Replace("%Y", now.Year.ToString());
+                time_str = time_str.Replace("%M", now.Month.ToString("D2"));
+                time_str = time_str.Replace("%d", now.Day.ToString("D2"));
+                time_str = time_str.Replace("%H", now.Hour.ToString("D2"));
+                time_str = time_str.Replace("%m", now.Minute.ToString("D2"));
                 time_str = time_str.Replace("%s", ((double)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString());
                 rotate_name = fi.Name + time_str;
             }

--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -645,12 +645,15 @@ namespace logrotate
                 time_str = time_str.Replace("%H", now.Hour.ToString("D2"));
                 time_str = time_str.Replace("%m", now.Minute.ToString("D2"));
                 time_str = time_str.Replace("%s", ((double)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds).ToString());
-                rotate_name = fi.Name + time_str;
+                // rotate_name = fi.Name + time_str;
+                rotate_name = Path.GetFileNameWithoutExtension(fi.Name) +
+                    time_str +
+                    Path.GetExtension(fi.Name);
             }
             else
             {
-                
                 rotate_name = fi.Name + "." + lrc.Start;
+                // rotate_name = Path.GetFileNameWithoutExtension(fi.Name) + "." + lrc.Start;
             }
             return rotate_name;
         }

--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -653,7 +653,6 @@ namespace logrotate
             else
             {
                 rotate_name = fi.Name + "." + lrc.Start;
-                // rotate_name = Path.GetFileNameWithoutExtension(fi.Name) + "." + lrc.Start;
             }
             return rotate_name;
         }


### PR DESCRIPTION
This pull request expands the format strings supported for interpolation by the dateformat configuration parameter and changes the application of this parameter such that file extensions are preserved.

The interpolation format strings now supported by the dateformat configuration parameter are as follows:

- %Y (Year)
- %m (Month)
- %d (Day)
- _%H (Hour, added)_
- _%M (Minutes, added)_
- %s (Seconds since epoch)

Additionally this patch modifies the application of this dateformat string such that the extension of the rotated file is preserved - For example, using the dateformat string "_%m%d" and assuming the date of 1st January, the rotated log file `debug.log` would become `debug.log_0101`.  With the change in this pull request, `debug.log` would become `debug_0101.log`.
