### PR TITLE
Config file parsing routine update and resource files refresh

### DIFF
--- a/logrotate/Program.cs
+++ b/logrotate/Program.cs
@@ -487,7 +487,7 @@ namespace logrotate
                 if (cla.Debug == false)
                 {
                     ShredFile sf = new ShredFile(m_filepath);
-                    sf.ShredIt(lrc.ShredCycles, cla.Debug);
+                    return sf.ShredIt(lrc.ShredCycles, cla.Debug);
                 }
             }
             else

--- a/logrotate/ShredFile.cs
+++ b/logrotate/ShredFile.cs
@@ -59,7 +59,7 @@ namespace logrotate
         /// <param name="bDebug">flag indicating if this is in debug mode (file will not be shredded if in debug mode)</param>
         /// <remarks>Will throw InvalidOperationException if it errors invoking Win32 API GetDiskFreeSpace</remarks>
         /// <returns>True if file was shredded, otherwise false</returns>
-        public bool ShredIt(int iShredCycles, bool bDebug)
+        public int ShredIt(int iShredCycles, bool bDebug)
         {
             Logging.Log(Strings.ShreddingFile + " " + sfile_path + " ShredCycles = " + iShredCycles,Logging.LogType.Debug);
 
@@ -129,9 +129,9 @@ namespace logrotate
             catch (Exception e)
             {
                 Logging.LogException(e);
-                return false;
+                return 1;
             }
-            return true;
+            return 0;
         }
     }
 }

--- a/logrotate/Strings.Designer.cs
+++ b/logrotate/Strings.Designer.cs
@@ -22,7 +22,7 @@ namespace logrotate {
     [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    internal class Strings {
+    public class Strings {
         
         private static global::System.Resources.ResourceManager resourceMan;
         
@@ -36,7 +36,7 @@ namespace logrotate {
         ///   Returns the cached ResourceManager instance used by this class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Resources.ResourceManager ResourceManager {
+        public static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
                     global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("logrotate.Strings", typeof(Strings).Assembly);
@@ -51,7 +51,7 @@ namespace logrotate {
         ///   resource lookups using this strongly typed resource class.
         /// </summary>
         [global::System.ComponentModel.EditorBrowsableAttribute(global::System.ComponentModel.EditorBrowsableState.Advanced)]
-        internal static global::System.Globalization.CultureInfo Culture {
+        public static global::System.Globalization.CultureInfo Culture {
             get {
                 return resourceCulture;
             }
@@ -63,7 +63,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Adding to config files to process.
         /// </summary>
-        internal static string AddingConfigFile {
+        public static string AddingConfigFile {
             get {
                 return ResourceManager.GetString("AddingConfigFile", resourceCulture);
             }
@@ -72,7 +72,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Adding files to rotate.
         /// </summary>
-        internal static string AddingFileToRotate {
+        public static string AddingFileToRotate {
             get {
                 return ResourceManager.GetString("AddingFileToRotate", resourceCulture);
             }
@@ -81,7 +81,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Setting alternate state file to.
         /// </summary>
-        internal static string AlternateStateFile {
+        public static string AlternateStateFile {
             get {
                 return ResourceManager.GetString("AlternateStateFile", resourceCulture);
             }
@@ -90,7 +90,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to comment.
         /// </summary>
-        internal static string Comment {
+        public static string Comment {
             get {
                 return ResourceManager.GetString("Comment", resourceCulture);
             }
@@ -99,7 +99,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Compressing rotated log file.
         /// </summary>
-        internal static string Compressing {
+        public static string Compressing {
             get {
                 return ResourceManager.GetString("Compressing", resourceCulture);
             }
@@ -108,7 +108,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Copying.
         /// </summary>
-        internal static string Copying {
+        public static string Copying {
             get {
                 return ResourceManager.GetString("Copying", resourceCulture);
             }
@@ -117,7 +117,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Copyright (C) 2012-2013 Ken Salter.
         /// </summary>
-        internal static string CopyRight {
+        public static string CopyRight {
             get {
                 return ResourceManager.GetString("CopyRight", resourceCulture);
             }
@@ -126,7 +126,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to could not be found.
         /// </summary>
-        internal static string CouldNotBeFound {
+        public static string CouldNotBeFound {
             get {
                 return ResourceManager.GetString("CouldNotBeFound", resourceCulture);
             }
@@ -135,7 +135,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Creating new empty log file.
         /// </summary>
-        internal static string CreateNewEmptyLogFile {
+        public static string CreateNewEmptyLogFile {
             get {
                 return ResourceManager.GetString("CreateNewEmptyLogFile", resourceCulture);
             }
@@ -144,7 +144,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Debug option set to true.
         /// </summary>
-        internal static string DebugOptionSet {
+        public static string DebugOptionSet {
             get {
                 return ResourceManager.GetString("DebugOptionSet", resourceCulture);
             }
@@ -153,16 +153,25 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Deleting file.
         /// </summary>
-        internal static string DeletingFile {
+        public static string DeletingFile {
             get {
                 return ResourceManager.GetString("DeletingFile", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error renaming file.
+        /// </summary>
+        public static string ErrorRenamingFile {
+            get {
+                return ResourceManager.GetString("ErrorRenamingFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Executing.
         /// </summary>
-        internal static string Executing {
+        public static string Executing {
             get {
                 return ResourceManager.GetString("Executing", resourceCulture);
             }
@@ -171,7 +180,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Executing FirstAction commands.
         /// </summary>
-        internal static string ExecutingFirstAction {
+        public static string ExecutingFirstAction {
             get {
                 return ResourceManager.GetString("ExecutingFirstAction", resourceCulture);
             }
@@ -180,7 +189,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Executing LastAction commands.
         /// </summary>
-        internal static string ExecutingLastAction {
+        public static string ExecutingLastAction {
             get {
                 return ResourceManager.GetString("ExecutingLastAction", resourceCulture);
             }
@@ -189,7 +198,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Executing Postrotate (SharedScripts) commands.
         /// </summary>
-        internal static string ExecutingPostRotateSharedScripts {
+        public static string ExecutingPostRotateSharedScripts {
             get {
                 return ResourceManager.GetString("ExecutingPostRotateSharedScripts", resourceCulture);
             }
@@ -198,7 +207,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Executing Prerotate (SharedScripts) commands.
         /// </summary>
-        internal static string ExecutingPreRotateSharedScripts {
+        public static string ExecutingPreRotateSharedScripts {
             get {
                 return ResourceManager.GetString("ExecutingPreRotateSharedScripts", resourceCulture);
             }
@@ -207,7 +216,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Execution output.
         /// </summary>
-        internal static string ExecutionOutput {
+        public static string ExecutionOutput {
             get {
                 return ResourceManager.GetString("ExecutionOutput", resourceCulture);
             }
@@ -216,7 +225,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to extension is in taboo list.
         /// </summary>
-        internal static string ExtInTaboo {
+        public static string ExtInTaboo {
             get {
                 return ResourceManager.GetString("ExtInTaboo", resourceCulture);
             }
@@ -225,7 +234,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to File.
         /// </summary>
-        internal static string File {
+        public static string File {
             get {
                 return ResourceManager.GetString("File", resourceCulture);
             }
@@ -234,7 +243,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Force option is set, will rotate.
         /// </summary>
-        internal static string ForceOptionRotate {
+        public static string ForceOptionRotate {
             get {
                 return ResourceManager.GetString("ForceOptionRotate", resourceCulture);
             }
@@ -243,7 +252,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Force option set to true.
         /// </summary>
-        internal static string ForceOptionSet {
+        public static string ForceOptionSet {
             get {
                 return ResourceManager.GetString("ForceOptionSet", resourceCulture);
             }
@@ -252,7 +261,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Global options must go above sections, ignoring.
         /// </summary>
-        internal static string GlobalOptionsAboveSections {
+        public static string GlobalOptionsAboveSections {
             get {
                 return ResourceManager.GetString("GlobalOptionsAboveSections", resourceCulture);
             }
@@ -261,7 +270,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to This may be freely redistributed under the terms of the GNU Public License.  .
         /// </summary>
-        internal static string GNURights {
+        public static string GNURights {
             get {
                 return ResourceManager.GetString("GNURights", resourceCulture);
             }
@@ -270,7 +279,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Key.
         /// </summary>
-        internal static string Key {
+        public static string Key {
             get {
                 return ResourceManager.GetString("Key", resourceCulture);
             }
@@ -279,7 +288,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Log file is empty.
         /// </summary>
-        internal static string LogFileEmpty {
+        public static string LogFileEmpty {
             get {
                 return ResourceManager.GetString("LogFileEmpty", resourceCulture);
             }
@@ -288,7 +297,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Looking for folders found in.
         /// </summary>
-        internal static string LookingForFolders {
+        public static string LookingForFolders {
             get {
                 return ResourceManager.GetString("LookingForFolders", resourceCulture);
             }
@@ -297,7 +306,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to -m/--mail option not supported, ignoring.
         /// </summary>
-        internal static string MailOptionSet {
+        public static string MailOptionSet {
             get {
                 return ResourceManager.GetString("MailOptionSet", resourceCulture);
             }
@@ -306,7 +315,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Matched folder.
         /// </summary>
-        internal static string MatchedFolder {
+        public static string MatchedFolder {
             get {
                 return ResourceManager.GetString("MatchedFolder", resourceCulture);
             }
@@ -315,7 +324,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to matching.
         /// </summary>
-        internal static string Matching {
+        public static string Matching {
             get {
                 return ResourceManager.GetString("Matching", resourceCulture);
             }
@@ -324,7 +333,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to new section.
         /// </summary>
-        internal static string NewSection {
+        public static string NewSection {
             get {
                 return ResourceManager.GetString("NewSection", resourceCulture);
             }
@@ -333,7 +342,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to No files found in.
         /// </summary>
-        internal static string NoFilesFound {
+        public static string NoFilesFound {
             get {
                 return ResourceManager.GetString("NoFilesFound", resourceCulture);
             }
@@ -342,7 +351,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to No folders found in.
         /// </summary>
-        internal static string NoFoldersFound {
+        public static string NoFoldersFound {
             get {
                 return ResourceManager.GetString("NoFoldersFound", resourceCulture);
             }
@@ -351,25 +360,25 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Will not rotate since log file is not greater than minimum file size.
         /// </summary>
-        internal static string NoRotateNotGTMinimumFileSize {
+        public static string NoRotateNotGTMinimumFileSize {
             get {
                 return ResourceManager.GetString("NoRotateNotGTMinimumFileSize", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No date found in status file for path.
+        ///   Looks up a localized string similar to Will not rotate since log file timestamp did not meet check policy or it was already rotated..
         /// </summary>
-        internal static string NoRotateNotGTTimeStamp {
+        public static string NoRotateNotGTTimeStamp {
             get {
                 return ResourceManager.GetString("NoRotateNotGTTimeStamp", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to No last rotation date found for that file on status log. Forcing file rotation..
+        ///   Looks up a localized string similar to No date found in status file for path.
         /// </summary>
-        internal static string NoStatusDate {
+        public static string NoStatusDate {
             get {
                 return ResourceManager.GetString("NoStatusDate", resourceCulture);
             }
@@ -378,7 +387,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to No timestamp directives are set true, skipping timestamp check.
         /// </summary>
-        internal static string NoTimestampDirectives {
+        public static string NoTimestampDirectives {
             get {
                 return ResourceManager.GetString("NoTimestampDirectives", resourceCulture);
             }
@@ -387,7 +396,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Parsing configuration file.
         /// </summary>
-        internal static string ParseConfigFile {
+        public static string ParseConfigFile {
             get {
                 return ResourceManager.GetString("ParseConfigFile", resourceCulture);
             }
@@ -396,7 +405,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Process include directive file.
         /// </summary>
-        internal static string ProcessInclude {
+        public static string ProcessInclude {
             get {
                 return ResourceManager.GetString("ProcessInclude", resourceCulture);
             }
@@ -405,7 +414,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Processing.
         /// </summary>
-        internal static string Processing {
+        public static string Processing {
             get {
                 return ResourceManager.GetString("Processing", resourceCulture);
             }
@@ -414,7 +423,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Procesing directives included in the global settings.
         /// </summary>
-        internal static string ProcessingGlobalDirective {
+        public static string ProcessingGlobalDirective {
             get {
                 return ResourceManager.GetString("ProcessingGlobalDirective", resourceCulture);
             }
@@ -423,7 +432,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to logrotate.
         /// </summary>
-        internal static string ProgramName {
+        public static string ProgramName {
             get {
                 return ResourceManager.GetString("ProgramName", resourceCulture);
             }
@@ -432,7 +441,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to read line.
         /// </summary>
-        internal static string ReadLine {
+        public static string ReadLine {
             get {
                 return ResourceManager.GetString("ReadLine", resourceCulture);
             }
@@ -441,7 +450,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Renaming.
         /// </summary>
-        internal static string Renaming {
+        public static string Renaming {
             get {
                 return ResourceManager.GetString("Renaming", resourceCulture);
             }
@@ -450,7 +459,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Rotate file based on file size.
         /// </summary>
-        internal static string RotateBasedonFileSize {
+        public static string RotateBasedonFileSize {
             get {
                 return ResourceManager.GetString("RotateBasedonFileSize", resourceCulture);
             }
@@ -459,16 +468,25 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Rotate will be simulated because Debug is true.
         /// </summary>
-        internal static string RotateSimulated {
+        public static string RotateSimulated {
             get {
                 return ResourceManager.GetString("RotateSimulated", resourceCulture);
             }
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Will rotate since log file is greater than maximum file size.
+        /// </summary>
+        public static string RotateWhenMaximumFileSize {
+            get {
+                return ResourceManager.GetString("RotateWhenMaximumFileSize", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Rotating file.
         /// </summary>
-        internal static string RotatingFile {
+        public static string RotatingFile {
             get {
                 return ResourceManager.GetString("RotatingFile", resourceCulture);
             }
@@ -477,7 +495,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to section(s).
         /// </summary>
-        internal static string Section {
+        public static string Section {
             get {
                 return ResourceManager.GetString("Section", resourceCulture);
             }
@@ -486,7 +504,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Sending email to.
         /// </summary>
-        internal static string SendingEmailTo {
+        public static string SendingEmailTo {
             get {
                 return ResourceManager.GetString("SendingEmailTo", resourceCulture);
             }
@@ -495,7 +513,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Setting.
         /// </summary>
-        internal static string Setting {
+        public static string Setting {
             get {
                 return ResourceManager.GetString("Setting", resourceCulture);
             }
@@ -504,7 +522,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Shredding file.
         /// </summary>
-        internal static string ShreddingFile {
+        public static string ShreddingFile {
             get {
                 return ResourceManager.GetString("ShreddingFile", resourceCulture);
             }
@@ -513,7 +531,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Skipping.
         /// </summary>
-        internal static string Skipping {
+        public static string Skipping {
             get {
                 return ResourceManager.GetString("Skipping", resourceCulture);
             }
@@ -522,7 +540,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Status file located in.
         /// </summary>
-        internal static string StateFileLocation {
+        public static string StateFileLocation {
             get {
                 return ResourceManager.GetString("StateFileLocation", resourceCulture);
             }
@@ -531,7 +549,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Timestamp directives are set true, doing timestamp checks.
         /// </summary>
-        internal static string TimestampDirectives {
+        public static string TimestampDirectives {
             get {
                 return ResourceManager.GetString("TimestampDirectives", resourceCulture);
             }
@@ -540,7 +558,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to  to .
         /// </summary>
-        internal static string To {
+        public static string To {
             get {
                 return ResourceManager.GetString("To", resourceCulture);
             }
@@ -549,7 +567,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Truncating original log file.
         /// </summary>
-        internal static string TruncateLogFile {
+        public static string TruncateLogFile {
             get {
                 return ResourceManager.GetString("TruncateLogFile", resourceCulture);
             }
@@ -558,7 +576,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Unknown command line argument.
         /// </summary>
-        internal static string UnknownCmdLineArg {
+        public static string UnknownCmdLineArg {
             get {
                 return ResourceManager.GetString("UnknownCmdLineArg", resourceCulture);
             }
@@ -567,7 +585,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Unknown directive.
         /// </summary>
-        internal static string UnknownDirective {
+        public static string UnknownDirective {
             get {
                 return ResourceManager.GetString("UnknownDirective", resourceCulture);
             }
@@ -576,7 +594,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Unknown size type.
         /// </summary>
-        internal static string UnknownSizeType {
+        public static string UnknownSizeType {
             get {
                 return ResourceManager.GetString("UnknownSizeType", resourceCulture);
             }
@@ -585,7 +603,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Updating rotation date in status file.
         /// </summary>
-        internal static string UpdateStatus {
+        public static string UpdateStatus {
             get {
                 return ResourceManager.GetString("UpdateStatus", resourceCulture);
             }
@@ -594,7 +612,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Usage: logrotate [-d|--debug] [-f|--force].
         /// </summary>
-        internal static string Usage1 {
+        public static string Usage1 {
             get {
                 return ResourceManager.GetString("Usage1", resourceCulture);
             }
@@ -603,7 +621,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to [-s|--state=statefile] [-v|--verbose] [-?|--help] [--usage].
         /// </summary>
-        internal static string Usage2 {
+        public static string Usage2 {
             get {
                 return ResourceManager.GetString("Usage2", resourceCulture);
             }
@@ -612,7 +630,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to &lt;configfile&gt;.
         /// </summary>
-        internal static string Usage3 {
+        public static string Usage3 {
             get {
                 return ResourceManager.GetString("Usage3", resourceCulture);
             }
@@ -621,7 +639,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to Verbose option set to true.
         /// </summary>
-        internal static string VerboseOptionSet {
+        public static string VerboseOptionSet {
             get {
                 return ResourceManager.GetString("VerboseOptionSet", resourceCulture);
             }
@@ -630,7 +648,7 @@ namespace logrotate {
         /// <summary>
         ///   Looks up a localized string similar to with wildcard pattern.
         /// </summary>
-        internal static string WithWildcardPattern {
+        public static string WithWildcardPattern {
             get {
                 return ResourceManager.GetString("WithWildcardPattern", resourceCulture);
             }

--- a/logrotate/Strings.resx
+++ b/logrotate/Strings.resx
@@ -312,4 +312,7 @@
   <data name="ExecutionOutput" xml:space="preserve">
     <value>Execution output</value>
   </data>
+  <data name="ErrorRenamingFile" xml:space="preserve">
+    <value>Error renaming file</value>
+  </data>
 </root>

--- a/logrotate/logrotate.csproj
+++ b/logrotate/logrotate.csproj
@@ -50,10 +50,10 @@
       <DependentUpon>Strings.resx</DependentUpon>
     </Compile>
     <Compile Include="ShredFile.cs" />
-    <Compile Include="strings.es.Designer.cs">
+    <Compile Include="Strings.es1.Designer.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
-      <DependentUpon>strings.es.resx</DependentUpon>
+      <DependentUpon>Strings.es.resx</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -62,13 +62,13 @@
     <None Include="Content\gnu_license.rtf" />
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="strings.es.resx">
+    <EmbeddedResource Include="Strings.es.resx">
       <SubType>Designer</SubType>
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>strings.es.Designer.cs</LastGenOutput>
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Strings.es1.Designer.cs</LastGenOutput>
     </EmbeddedResource>
     <EmbeddedResource Include="Strings.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
+      <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>Strings.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/logrotate/strings.es.resx
+++ b/logrotate/strings.es.resx
@@ -309,4 +309,10 @@
   <data name="ExecutionOutput" xml:space="preserve">
     <value>Resultado de la ejecución</value>
   </data>
+  <data name="RotateWhenMaximumFileSize" xml:space="preserve">
+    <value>Rotando el archivo (supera el tamaño máximo configurado)</value>
+  </data>
+  <data name="ErrorRenamingFile" xml:space="preserve">
+    <value>Error al renombrar el archivo</value>
+  </data>
 </root>


### PR DESCRIPTION
String operations during config file parsing have been replaced by a more robust regular expression logic routines.

DeleteRotateFile and ShredIt functions have been also refreshed so DeleteRotateFile returns an integer value to identify if it has been able to complete the operation and program can continue with the process.

Additionally Spanish literals has been updated with the new pull request update. Other literals on resource files have been added as required.