### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-chocolatey.yml
+++ b/.github/workflows/publish-chocolatey.yml
@@ -11,6 +11,9 @@ on:
   # release:
   #   types: [published]
 
+permissions:
+  contents: read
+
 jobs:
   publish-chocolatey:
     runs-on: windows-latest


### PR DESCRIPTION
Potential fix for [https://github.com/plecos/logrotatewin/security/code-scanning/1](https://github.com/plecos/logrotatewin/security/code-scanning/1)

To fix the problem, add a `permissions` block explicitly to the workflow. The minimal required is `contents: read`, unless additional scopes are needed (their absence in this snippet suggests they are not). Place this at the root of the file, before `jobs:`, so all jobs within the workflow inherit these permissions unless overridden. No changes to steps or logic are needed. This is a one-line fix, adding:

```yaml
permissions:
  contents: read
```

between the triggers (`on:`) and the `jobs:` block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
