### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/plecos/logrotatewin/security/code-scanning/2](https://github.com/plecos/logrotatewin/security/code-scanning/2)

The best fix is to explicitly add a `permissions` block granting only the minimum necessary privileges. Reviewing the workflow, all actions and steps (checkout code, setup .NET, restore/build/test, upload artifacts) operate using the code and artifacts but do not require write access to repository contents, issues, or pull requests. Therefore, you can safely add the following at either the workflow or the job level:
```yaml
permissions:
  contents: read
```
This restricts the `GITHUB_TOKEN` to read-only access to repository contents for all jobs. The edit should be at the top level, below the `name:` and (optionally) before `on:`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
