### PR TITLE
Add regression tests for issue #60 (quoted wildcard path)

### DIFF
--- a/logrotate.Tests/Integration/ConfigParsingTests.cs
+++ b/logrotate.Tests/Integration/ConfigParsingTests.cs
@@ -492,5 +492,89 @@ daily
                 TestHelpers.CleanupPath(configFile);
             }
         }
+
+        [Fact]
+        public void ParseConfig_WithQuotedWildcardPath_ShouldRotateMatchingFiles()
+        {
+            // Regression test for issue #60: a quoted path that also contains a wildcard
+            // (e.g. "C:\path\*.log") with the opening brace on the same line was reported
+            // as an "Unknown directive" followed by "No folders found in section(s)",
+            // meaning the section header was never recognized.
+            // https://github.com/plecos/logrotatewin/issues/60
+
+            // Arrange
+            string logDir = Path.Combine(TestDir, "log");
+            Directory.CreateDirectory(logDir);
+            string log1 = Path.Combine(logDir, "prod.log");
+            string log2 = Path.Combine(logDir, "app.log");
+            File.WriteAllText(log1, "Prod log\n");
+            File.WriteAllText(log2, "App log\n");
+
+            string wildcardPattern = Path.Combine(logDir, "*.log");
+            string stateFile = Path.Combine(TestDir, "state.txt");
+            string configContent = $@"
+""{wildcardPattern}"" {{
+    rotate 2
+}}
+";
+            string configFile = TestHelpers.CreateTempConfigFile(configContent);
+
+            try
+            {
+                // Act
+                RunLogRotate("-s", stateFile, "-f", configFile);
+
+                // Assert
+                File.Exists($"{log1}.1").Should().BeTrue("prod.log matched by quoted wildcard should be rotated");
+                File.Exists($"{log2}.1").Should().BeTrue("app.log matched by quoted wildcard should be rotated");
+            }
+            finally
+            {
+                TestHelpers.CleanupPath(configFile);
+            }
+        }
+
+        [Fact]
+        public void ParseConfig_WithQuotedWildcardPathFromIssue60_ShouldRotate()
+        {
+            // Regression test for issue #60 using the reporter's full directive set:
+            // quoted wildcard path + same-line brace + copytruncate + sharedscripts + olddir.
+
+            // Arrange
+            string logDir = Path.Combine(TestDir, "log");
+            string archiveDir = Path.Combine(TestDir, "archive");
+            Directory.CreateDirectory(logDir);
+            string log1 = Path.Combine(logDir, "prod.log");
+            File.WriteAllText(log1, "Prod log\n");
+
+            string wildcardPattern = Path.Combine(logDir, "*.log");
+            string stateFile = Path.Combine(TestDir, "state.txt");
+            string configContent = $@"
+""{wildcardPattern}"" {{
+    daily
+    rotate 30
+    missingok
+    notifempty
+    copytruncate
+    sharedscripts
+    olddir ""{archiveDir}""
+}}
+";
+            string configFile = TestHelpers.CreateTempConfigFile(configContent);
+
+            try
+            {
+                // Act
+                RunLogRotate("-s", stateFile, "-f", configFile);
+
+                // Assert - the rotated file lands in olddir
+                File.Exists(Path.Combine(archiveDir, "prod.log.1")).Should().BeTrue(
+                    "prod.log matched by quoted wildcard should be rotated into olddir");
+            }
+            finally
+            {
+                TestHelpers.CleanupPath(configFile);
+            }
+        }
     }
 }


### PR DESCRIPTION
Relates to #60.

## What

Adds two integration tests reproducing the config from issue #60 — a **quoted path that also contains a wildcard**, with the opening brace on the same line:

```
"C:\inetpub\wwwroot\shared\var\log\*.log" {
    ...
}
```

The reporter (v0.0.28) saw:

```
[WRN]: Unknown directive "C:\...\*.log" {
[ERR]: No folders found in section(s)
```

which means the section header was never recognized — the whole `path {` line was passed to the directive parser and `FilePathConfigSection` stayed empty.

## Why a test first

We already have passing tests for a quoted **concrete** path (`ParseConfig_WithQuotedPaths_ShouldHandlePathsWithSpaces`) and for an **unquoted** wildcard (`RotateLog_WithWildcard_ShouldRotateAllMatchingFiles`), but **none for the quoted-wildcard combination** the reporter used.

I diffed `GetModifiedFile`/`ProcessConfileFileSection` between the `v0.0.28` tag and current `master` — the section-parsing logic is essentially unchanged, so this may **still reproduce on latest**. The net48 test suite can't run on macOS (needs mono/Windows), so these tests exist to let **Windows CI** confirm whether current `master` reproduces the bug, and to serve as regression coverage once it's fixed.

## Tests added

- `ParseConfig_WithQuotedWildcardPath_ShouldRotateMatchingFiles` — minimal repro (quoted wildcard + same-line brace, two matching files).
- `ParseConfig_WithQuotedWildcardPathFromIssue60_ShouldRotate` — the reporter's full directive set (`copytruncate`, `sharedscripts`, `olddir`), asserting the rotated file lands in `olddir`.

If CI is **red**, we've confirmed and located the bug and can fix it on top of this branch. If CI is **green**, the bug was already fixed since v0.0.28 and we can advise the reporter to upgrade — with regression coverage now in place either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)